### PR TITLE
Abstracting curves

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ testNonInteractive = do
 
 ```
 
+Curves
+======
+
+This Schnorr implementation offers support for both SECp256k1 and Curve25519 curves,
+which are Koblitz and Montgomery curves, respectively. Further information about
+these curves can be found in the Uplink docs:
+
+[SECp256k1 curve](https://www.adjoint.io/docs/cryptography.html#id1 "SECp256k1 curve")
+[Curve25519 curve](https://www.adjoint.io/docs/cryptography.html#id2 "Curve25519 curve")
+
 **References**:
 
 1.  Hao, F. "Schnorr Non-interactive Zero-Knowledge Proof." Newcastle University, UK, 2017

--- a/package.yaml
+++ b/package.yaml
@@ -71,6 +71,7 @@ library:
     - Curve
     - NonInteractive
     - Interactive
+    - Curve25519
 
 
 tests:

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -1,55 +1,71 @@
 module Curve
   ( Curve(..)
   , Curve25519(..)
-  , curve25519
+  , SECCurve(..)
   ) where
 
-import qualified Crypto.PubKey.ECC.Prim as ECC
-import qualified Crypto.PubKey.ECC.Types as ECC
-import qualified Crypto.ECC as ECC hiding (Point)
+import qualified Crypto.PubKey.ECC.Generate   as ECC
+import qualified Crypto.PubKey.ECC.Prim       as ECC
+import qualified Crypto.PubKey.ECC.Types      as ECC
+import qualified Crypto.PubKey.ECC.ECDSA      as ECDSA
+import           Crypto.Random.Types          (MonadRandom)
 import           Protolude
 
-class Curve a where
+import qualified Curve25519
+
+data Curve25519 = Curve25519 deriving Show
+newtype SECCurve = SECCurve { unSEC :: ECC.CurveName } deriving Show
+
+class (Show a) => Curve a where
   curve :: a -> ECC.Curve
   cc :: a -> ECC.CurveCommon
+  a :: a -> Integer
   n :: a -> Integer
   g :: a -> ECC.Point
   h :: a -> Integer
+  isPointValid :: a -> ECC.Point -> Bool
+  pointMul :: a -> Integer -> ECC.Point -> ECC.Point
+  pointAdd :: a -> ECC.Point -> ECC.Point -> ECC.Point
+  pointNegate :: a -> ECC.Point -> ECC.Point
+  pointDouble :: a -> ECC.Point -> ECC.Point
+  generateQ :: a -> Integer -> ECC.Point
+  generateKeys :: MonadRandom m => a -> m (ECDSA.PublicKey, ECDSA.PrivateKey)
+  isPointAtInfinity :: a -> ECC.Point -> Bool
+  pointAddTwoMuls :: a -> Integer -> ECC.Point -> Integer -> ECC.Point -> ECC.Point
+  pointBaseMul :: a -> Integer -> ECC.Point
 
-instance Curve ECC.CurveName where
-  curve = ECC.getCurveByName
+instance Curve SECCurve where
+  curve = ECC.getCurveByName . unSEC
   cc = ECC.common_curve . curve
+  a = ECC.ecc_a . cc
   n = ECC.ecc_n . cc
   g = ECC.ecc_g . cc
   h = ECC.ecc_h . cc
-
-data Curve25519 = Curve25519 deriving Show
--- For the ~128-bit security level, the prime 2^255 - 19 is recommended
--- for performance on a wide range of architectures.
--- v^2 = u^3 + A*u^2 + u, called "curve25519":
--- p  2^255 - 19
--- A  486662
--- order  2^252 + 0x14def9dea2f79cd65812631a5cf5d3ed
--- cofactor  8
--- U(P)  9
--- V(P)  147816194475895447910205935684099868872646061346164752889648818
---    37755586237401
--- The base point is u = 9, v = 1478161944758954479102059356840998688726
--- 4606134616475288964881837755586237401
-curve25519 :: ECC.Curve
-curve25519 = ECC.CurveFP $ ECC.CurvePrime
-  0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFED
-  ECC.CurveCommon
-      { ecc_a = 0x76D06
-      , ecc_b = 0x1
-      , ecc_g = ECC.Point 0x9 0x20AE19A1B8A086B4E01EDD2C7748D14C923D4D7E6D7C61B229E9C5A27ECED3D9
-      , ecc_n = 0x1000000000000000000000000000000014DEF9DEA2F79CD65812631A5CF5D3ED
-      , ecc_h = 8
-      }
+  isPointValid = ECC.isPointValid . curve
+  pointMul = ECC.pointMul . curve
+  pointAdd = ECC.pointAdd . curve
+  pointNegate = ECC.pointNegate . curve
+  pointDouble = ECC.pointDouble . curve
+  generateQ = ECC.generateQ . curve
+  generateKeys = ECC.generate . curve
+  isPointAtInfinity = const ECC.isPointAtInfinity
+  pointAddTwoMuls = ECC.pointAddTwoMuls . curve
+  pointBaseMul = ECC.pointBaseMul . curve
 
 instance Curve Curve25519 where
-  curve = const curve25519
+  curve = const Curve25519.curve25519
   cc = ECC.common_curve . curve
+  a = ECC.ecc_a . cc
   n = ECC.ecc_n . cc
   g = ECC.ecc_g . cc
   h = ECC.ecc_h . cc
+  isPointValid = Curve25519.isPointValid . curve
+  pointMul = Curve25519.pointMul . curve
+  pointAdd = Curve25519.pointAdd . curve
+  pointNegate = Curve25519.pointNegate . curve
+  pointDouble = Curve25519.pointDouble . curve
+  generateQ = Curve25519.generateQ . curve
+  generateKeys = Curve25519.generateKeys . curve
+  isPointAtInfinity = const ECC.isPointAtInfinity
+  pointAddTwoMuls = Curve25519.pointAddTwoMuls . curve
+  pointBaseMul = Curve25519.pointBaseMul . curve

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -1,5 +1,6 @@
 module Curve
   ( Curve(..)
+  , Curve25519(..)
   ) where
 
 import qualified Crypto.PubKey.ECC.Prim as ECC
@@ -21,9 +22,33 @@ instance Curve ECC.CurveName where
   g = ECC.ecc_g . cc
   h = ECC.ecc_h . cc
 
-instance Curve ECC.Curve_X25519 where
-  curve = undefined
-  cc = undefined
-  n = undefined
-  g = undefined
-  h = undefined
+data Curve25519 = Curve25519 deriving Show
+-- For the ~128-bit security level, the prime 2^255 - 19 is recommended
+-- for performance on a wide range of architectures.
+-- v^2 = u^3 + A*u^2 + u, called "curve25519":
+-- p  2^255 - 19
+-- A  486662
+-- order  2^252 + 0x14def9dea2f79cd65812631a5cf5d3ed
+-- cofactor  8
+-- U(P)  9
+-- V(P)  147816194475895447910205935684099868872646061346164752889648818
+--    37755586237401
+-- The base point is u = 9, v = 1478161944758954479102059356840998688726
+-- 4606134616475288964881837755586237401
+curve25519 :: ECC.Curve
+curve25519 = ECC.CurveFP $ ECC.CurvePrime
+  0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFED
+  ECC.CurveCommon
+      { ecc_a = 0x76D06
+      , ecc_b = 0x1
+      , ecc_g = ECC.Point 0x9 0x20AE19A1B8A086B4E01EDD2C7748D14C923D4D7E6D7C61B229E9C5A27ECED3D9
+      , ecc_n = 0x1000000000000000000000000000000014DEF9DEA2F79CD65812631A5CF5D3ED
+      , ecc_h = 8
+      }
+
+instance Curve Curve25519 where
+  curve = const curve25519
+  cc = ECC.common_curve . curve
+  n = ECC.ecc_n . cc
+  g = ECC.ecc_g . cc
+  h = ECC.ecc_h . cc

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -1,28 +1,29 @@
 module Curve
-  ( secp256k1
-  , n
-  , g
-  , h
+  ( Curve(..)
   ) where
 
-import           Crypto.PubKey.ECC.Prim
-import           Crypto.PubKey.ECC.Types
+import qualified Crypto.PubKey.ECC.Prim as ECC
+import qualified Crypto.PubKey.ECC.Types as ECC
+import qualified Crypto.ECC as ECC hiding (Point)
 import           Protolude
 
-secp256k1 :: Curve
-secp256k1 = getCurveByName SEC_p256k1
+class Curve a where
+  curve :: a -> ECC.Curve
+  cc :: a -> ECC.CurveCommon
+  n :: a -> Integer
+  g :: a -> ECC.Point
+  h :: a -> Integer
 
-cc :: CurveCommon
-cc = common_curve secp256k1
+instance Curve ECC.CurveName where
+  curve = ECC.getCurveByName
+  cc = ECC.common_curve . curve
+  n = ECC.ecc_n . cc
+  g = ECC.ecc_g . cc
+  h = ECC.ecc_h . cc
 
--- | Order of the curve
-n :: Integer
-n = ecc_n cc
-
--- | Generator base point
-g :: Point
-g = ecc_g cc
-
--- | Curve cofactor
-h :: Integer
-h = ecc_h cc
+instance Curve ECC.Curve_X25519 where
+  curve = undefined
+  cc = undefined
+  n = undefined
+  g = undefined
+  h = undefined

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -1,6 +1,7 @@
 module Curve
   ( Curve(..)
   , Curve25519(..)
+  , curve25519
   ) where
 
 import qualified Crypto.PubKey.ECC.Prim as ECC

--- a/src/Curve25519.hs
+++ b/src/Curve25519.hs
@@ -1,0 +1,158 @@
+module Curve25519
+  ( curve25519
+  , isPointValid
+  , pointMul
+  , pointAdd
+  , pointNegate
+  , pointDouble
+  , pointAddTwoMuls
+  , pointBaseMul
+  , generateQ
+  , generateKeys
+  ) where
+
+import Protolude
+
+import qualified Crypto.PubKey.ECC.Prim       as ECC
+import qualified Crypto.PubKey.ECC.Types      as ECC
+import qualified Crypto.PubKey.ECC.Generate   as ECC
+import           Crypto.Number.Generate       (generateBetween)
+import qualified Crypto.PubKey.ECC.ECDSA      as ECDSA
+import           Crypto.Random.Types          (MonadRandom)
+import           Crypto.Number.ModArithmetic  (inverse)
+
+-- For the ~128-bit security level, the prime 2^255 - 19 is recommended
+-- for performance on a wide range of architectures.
+-- v^2 = u^3 + A*u^2 + u, called "curve25519":
+-- p  2^255 - 19
+-- A  486662
+-- order  2^252 + 0x14def9dea2f79cd65812631a5cf5d3ed = 7237005577332262213973186563042994240857116359379907606001950938285454250989
+-- cofactor  8
+-- U(P)  9
+-- V(P)  14781619447589544791020593568409986887264606134616475288964881837755586237401
+-- The base point is u = 9, v = 14781619447589544791020593568409986887264606134616475288964881837755586237401
+curve25519 :: ECC.Curve
+curve25519 = ECC.CurveFP $ ECC.CurvePrime
+  0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFED
+  ECC.CurveCommon
+      { ecc_a = 0x76D06
+      , ecc_b = 0x1
+      , ecc_g = ECC.Point 0x9 0x20AE19A1B8A086B4E01EDD2C7748D14C923D4D7E6D7C61B229E9C5A27ECED3D9
+      , ecc_n = 0x1000000000000000000000000000000014DEF9DEA2F79CD65812631A5CF5D3ED
+      , ecc_h = 0x8
+      }
+
+isPointValid :: ECC.Curve -> ECC.Point -> Bool
+isPointValid _                                   ECC.PointO      = True
+isPointValid (ECC.CurveFP (ECC.CurvePrime p cc)) (ECC.Point x y) =
+  isValid x && isValid y
+    && (y ^ (2 :: Int)) `eqModP` (x ^ (3 :: Int) + a * (x ^ (2 :: Int)) + b * x)
+  where a  = ECC.ecc_a cc
+        b  = ECC.ecc_b cc
+        eqModP z1 z2 = (z1 `mod` p) == (z2 `mod` p)
+        isValid e = e >= 0 && e < p
+isPointValid _ _ = notImplemented
+
+pointDouble :: ECC.Curve -> ECC.Point -> ECC.Point
+pointDouble _ ECC.PointO = ECC.PointO
+pointDouble (ECC.CurveFP (ECC.CurvePrime pr cc)) (ECC.Point xp yp) =
+  fromMaybe ECC.PointO $ do
+    lambda <- divmod (3 * xp ^ (2::Int) + 2 * a * xp + 1) (2 * yp) pr
+    let xr = (lambda ^ (2::Int) - a - 2 * xp) `mod` pr
+        yr = (lambda * (xp - xr) - yp) `mod` pr
+    return $ ECC.Point xr yr
+  where a = ECC.ecc_a cc
+pointDouble _ _ = notImplemented
+
+-- /WARNING:/ Vulnerable to timing attacks.
+pointMul :: ECC.Curve -> Integer -> ECC.Point -> ECC.Point
+pointMul _ _ ECC.PointO = ECC.PointO
+pointMul c n p
+    | n <  0 = pointMul c (-n) (pointNegate c p)
+    | n == 0 = ECC.PointO
+    | n == 1 = p
+    | odd n = pointAdd c p (pointMul c (n - 1) p)
+    | otherwise = pointMul c (n `div` 2) (pointDouble c p)
+
+-- | Elliptic Curve point negation:
+-- @pointNegate c p@ returns point @q@ such that @pointAdd c p q == PointO@.
+pointNegate :: ECC.Curve -> ECC.Point -> ECC.Point
+pointNegate _               ECC.PointO      = ECC.PointO
+pointNegate (ECC.CurveFP c) (ECC.Point x y) = ECC.Point x (ECC.ecc_p c - y)
+pointNegate _ _                             = notImplemented
+
+-- /WARNING:/ Vulnerable to timing attacks.
+pointAdd :: ECC.Curve -> ECC.Point -> ECC.Point -> ECC.Point
+pointAdd _ ECC.PointO ECC.PointO = ECC.PointO
+pointAdd _ ECC.PointO q = q
+pointAdd _ p ECC.PointO = p
+pointAdd c p q
+  | p == q = pointDouble c p
+  | p == pointNegate c q = ECC.PointO
+pointAdd curve@(ECC.CurveFP (ECC.CurvePrime pr cc)) (ECC.Point xp yp) (ECC.Point xq yq)
+    = fromMaybe ECC.PointO $ do
+        lambda <- divmod (yq - yp) (xq - xp) pr
+        let xr = (lambda ^ (2::Int) - a - xp - xq) `mod` pr
+            yr = (lambda * (xp - xr) - yp) `mod` pr
+        return $ ECC.Point xr yr
+  where a = ECC.ecc_a cc
+pointAdd _ _ _ = notImplemented
+
+-- | Elliptic curve double-scalar multiplication (uses Shamir's trick).
+--
+-- > pointAddTwoMuls c n1 p1 n2 p2 == pointAdd c (pointMul c n1 p1)
+-- >                                             (pointMul c n2 p2)
+--
+-- /WARNING:/ Vulnerable to timing attacks.
+pointAddTwoMuls :: ECC.Curve -> Integer -> ECC.Point -> Integer -> ECC.Point -> ECC.Point
+pointAddTwoMuls _ _  ECC.PointO _  ECC.PointO = ECC.PointO
+pointAddTwoMuls c _  ECC.PointO n2 p2     = pointMul c n2 p2
+pointAddTwoMuls c n1 p1     _  ECC.PointO = pointMul c n1 p1
+pointAddTwoMuls c n1 p1     n2 p2
+    | n1 < 0    = pointAddTwoMuls c (-n1) (pointNegate c p1) n2 p2
+    | n2 < 0    = pointAddTwoMuls c n1 p1 (-n2) (pointNegate c p2)
+    | otherwise = go (n1, n2)
+
+  where
+    p0 = pointAdd c p1 p2
+
+    go (0,  0 ) = ECC.PointO
+    go (k1, k2) =
+        let q = pointDouble c $ go (k1 `div` 2, k2 `div` 2)
+        in case (odd k1, odd k2) of
+            (True  , True  ) -> pointAdd c p0 q
+            (True  , False ) -> pointAdd c p1 q
+            (False , True  ) -> pointAdd c p2 q
+            (False , False ) -> q
+
+-- | Elliptic curve point multiplication using the base
+--
+-- /WARNING:/ Vulnerable to timing attacks.
+pointBaseMul :: ECC.Curve -> Integer -> ECC.Point
+pointBaseMul c n = pointMul c n (ECC.ecc_g $ ECC.common_curve c)
+
+-- /WARNING:/ Vulnerable to timing attacks.
+generateQ :: ECC.Curve
+          -> Integer
+          -> ECC.Point
+generateQ curve d = pointMul curve d g
+  where g = ECC.ecc_g $ ECC.common_curve curve
+
+-- | Generate a pair of (private, public) key.
+--
+-- /WARNING:/ Vulnerable to timing attacks.
+generateKeys :: MonadRandom m
+         => ECC.Curve -- ^ Elliptic Curve
+         -> m (ECDSA.PublicKey, ECDSA.PrivateKey)
+generateKeys curve = do
+    d <- generateBetween 1 (n - 1)
+    let q = generateQ curve d
+    return (ECDSA.PublicKey curve q, ECDSA.PrivateKey curve d)
+  where
+        n = ECC.ecc_n $ ECC.common_curve curve
+
+-- | div and mod
+divmod :: Integer -> Integer -> Integer -> Maybe Integer
+divmod y x m = do
+    i <- inverse (x `mod` m) m
+    return $ y * i `mod` m

--- a/src/Curve25519.hs
+++ b/src/Curve25519.hs
@@ -22,8 +22,10 @@ import           Crypto.Random.Types          (MonadRandom)
 import           Crypto.Number.ModArithmetic  (inverse)
 
 -- | Curve25519 definition
+--
 -- For the ~128-bit security level, the prime 2^255 - 19 is recommended
 -- for performance on a wide range of architectures.
+--
 -- * @v^2 = u^3 + A*u^2 + u@:
 -- * p  2^255 - 19
 -- * A  486662
@@ -88,6 +90,7 @@ pointMul c n p
     | otherwise = pointMul c (n `div` 2) (pointDouble c p)
 
 -- | Elliptic Curve point negation:
+--
 -- @pointNegate c p@ returns point @q@ such that @pointAdd c p q == PointO@.
 pointNegate :: ECC.Curve -> ECC.Point -> ECC.Point
 pointNegate _               ECC.PointO      = ECC.PointO

--- a/src/Interactive.hs
+++ b/src/Interactive.hs
@@ -19,5 +19,3 @@ import           Schnorr
 -- | Generate challenge from a given message
 generateChallenge :: MonadRandom m => ByteString -> m Challenge
 generateChallenge msg = generateBetween 0  (2^BS.length msg - 1)
-
-

--- a/src/NonInteractive.hs
+++ b/src/NonInteractive.hs
@@ -12,18 +12,15 @@ module NonInteractive (
 
 import           Protolude                  hiding (hash)
 import           Crypto.Hash
-import qualified Crypto.PubKey.ECC.ECDSA as ECDSA
-import       qualified    Crypto.PubKey.ECC.Types
-import qualified           Crypto.PubKey.ECC.Types    as ECC
-
+import qualified Crypto.PubKey.ECC.ECDSA    as ECDSA
+import qualified Crypto.PubKey.ECC.Types
+import qualified Crypto.PubKey.ECC.Types    as ECC
 import           Crypto.Number.Serialize    (os2ip)
 import qualified Data.ByteArray             as BA
-
 import           Data.ByteString
 import           Data.Monoid
 
 import qualified Curve
-import           Schnorr
 
 -- | Append coordinates to create a hashable type.
 -- It will be used in the protocol to make the challenge

--- a/src/NonInteractive.hs
+++ b/src/NonInteractive.hs
@@ -13,7 +13,6 @@ module NonInteractive (
 import           Protolude                  hiding (hash)
 import           Crypto.Hash
 import qualified Crypto.PubKey.ECC.ECDSA    as ECDSA
-import qualified Crypto.PubKey.ECC.Types
 import qualified Crypto.PubKey.ECC.Types    as ECC
 import           Crypto.Number.Serialize    (os2ip)
 import qualified Data.ByteArray             as BA

--- a/src/Schnorr.hs
+++ b/src/Schnorr.hs
@@ -59,8 +59,7 @@ verify curveName pubKey pubCommit challenge r =
     validPoint = Curve.isPointValid curveName (ECDSA.public_q pubKey)
     infinity = Curve.isPointAtInfinity curveName $
       Curve.pointMul curveName h (ECDSA.public_q pubKey)
-    verifyPubKey = validPoint
-     -- && not (infinity (ECDSA.public_q pubKey))
+    verifyPubKey = validPoint && not infinity
     t = Curve.pointAddTwoMuls curveName r g challenge (ECDSA.public_q pubKey)
     verifyPubCommit = pubCommit == t
     curve = Curve.curve curveName

--- a/src/Schnorr.hs
+++ b/src/Schnorr.hs
@@ -3,7 +3,6 @@ module Schnorr
   , Response
   , PublicCommitment
   , PrivateCommitment
-  , generateKeys
   , generateCommitment
   , computeResponse
   , verify
@@ -15,13 +14,13 @@ import           Crypto.Random.Types (MonadRandom)
 import           Crypto.Number.Serialize    (os2ip)
 import qualified Crypto.PubKey.ECC.ECDSA    as ECDSA
 import qualified Crypto.PubKey.ECC.Generate as ECC
-import          qualified Crypto.PubKey.ECC.Prim     as ECC
-import qualified           Crypto.PubKey.ECC.Types    as ECC
-import          qualified Data.ByteString            as BS
+import qualified Crypto.PubKey.ECC.Prim     as ECC
+import qualified Crypto.PubKey.ECC.Types    as ECC
+import qualified Data.ByteString            as BS
 import           Data.Monoid
-import           Protolude                  hiding (hash)
+import           Protolude
 
-import      qualified     Curve
+import qualified Curve
 
 -----------------------------------------------------
 -- Schnorr Indentification Scheme - Elliptic Curve
@@ -31,10 +30,6 @@ type Challenge = Integer
 type Response = Integer
 type PublicCommitment = ECC.Point
 type PrivateCommitment = Integer
-
--- | Generate public and private keys
-generateKeys :: (MonadRandom m, Curve.Curve c) => c -> m (ECDSA.PublicKey, ECDSA.PrivateKey)
-generateKeys = ECC.generate . Curve.curve
 
 -- | Compute response from previous generated values:
 -- private commitment value, prover's private key and verifier's challenge
@@ -58,11 +53,15 @@ verify
   -> Challenge
   -> Response
   -> Bool
-verify curveName pubKey pubCommit challenge r = verifyPubKey && verifyPubCommit
+verify curveName pubKey pubCommit challenge r =
+  verifyPubKey && verifyPubCommit
   where
-    verifyPubKey = ECC.isPointValid curve (ECDSA.public_q pubKey)
-        && not (ECC.isPointAtInfinity $ ECC.pointMul curve h (ECDSA.public_q pubKey))
-    t = ECC.pointAddTwoMuls curve r g challenge (ECDSA.public_q pubKey)
+    validPoint = Curve.isPointValid curveName (ECDSA.public_q pubKey)
+    infinity = Curve.isPointAtInfinity curveName $
+      Curve.pointMul curveName h (ECDSA.public_q pubKey)
+    verifyPubKey = validPoint
+     -- && not (infinity (ECDSA.public_q pubKey))
+    t = Curve.pointAddTwoMuls curveName r g challenge (ECDSA.public_q pubKey)
     verifyPubCommit = pubCommit == t
     curve = Curve.curve curveName
     g = Curve.g curveName
@@ -77,5 +76,5 @@ generateCommitment
   -> m (PublicCommitment, PrivateCommitment)
 generateCommitment curveName = do
   k <- generateBetween 0 (Curve.n curveName - 1)
-  let k' = ECC.pointBaseMul (Curve.curve curveName) k
+  let k' = Curve.pointBaseMul curveName k
   pure (k', k)

--- a/src/Schnorr.hs
+++ b/src/Schnorr.hs
@@ -14,48 +14,68 @@ import           Crypto.Number.Generate     (generateBetween)
 import           Crypto.Random.Types (MonadRandom)
 import           Crypto.Number.Serialize    (os2ip)
 import qualified Crypto.PubKey.ECC.ECDSA    as ECDSA
-import           Crypto.PubKey.ECC.Generate
-import           Crypto.PubKey.ECC.Prim
-import           Crypto.PubKey.ECC.Types
-import           Data.ByteString            as BS
+import qualified Crypto.PubKey.ECC.Generate as ECC
+import          qualified Crypto.PubKey.ECC.Prim     as ECC
+import qualified           Crypto.PubKey.ECC.Types    as ECC
+import          qualified Data.ByteString            as BS
 import           Data.Monoid
 import           Protolude                  hiding (hash)
 
-import qualified Curve
+import      qualified     Curve
 
--------------------------------------------------------------------------------
--- Schnorr Indentification Scheme - Elliptic Curve (SECP256k1)
--------------------------------------------------------------------------------
+-----------------------------------------------------
+-- Schnorr Indentification Scheme - Elliptic Curve
+-----------------------------------------------------
 
 type Challenge = Integer
 type Response = Integer
-type PublicCommitment = Point
+type PublicCommitment = ECC.Point
 type PrivateCommitment = Integer
 
 -- | Generate public and private keys
-generateKeys :: MonadRandom m => m (ECDSA.PublicKey, ECDSA.PrivateKey)
-generateKeys = generate Curve.secp256k1
+generateKeys :: (MonadRandom m, Curve.Curve c) => c -> m (ECDSA.PublicKey, ECDSA.PrivateKey)
+generateKeys = ECC.generate . Curve.curve
 
 -- | Compute response from previous generated values:
 -- private commitment value, prover's private key and verifier's challenge
-computeResponse :: PrivateCommitment -> ECDSA.PrivateKey -> Challenge -> Response
-computeResponse pc pk challenge = pc - ECDSA.private_d pk * challenge `mod` Curve.n
+computeResponse
+  :: Curve.Curve c
+  => c
+  -> PrivateCommitment
+  -> ECDSA.PrivateKey
+  -> Challenge
+  -> Response
+computeResponse curveName pc pk challenge =
+  pc - ECDSA.private_d pk * challenge `mod` Curve.n curveName
 
 -- | Verify proof given by the prover.
 -- It receives a public key, a commitment, a challenge and a response value.
-verify :: ECDSA.PublicKey -> PublicCommitment -> Challenge -> Response -> Bool
-verify pubKey pubCommit challenge r = verifyPubKey && verifyPubCommit
+verify
+  :: Curve.Curve c
+  => c
+  -> ECDSA.PublicKey
+  -> PublicCommitment
+  -> Challenge
+  -> Response
+  -> Bool
+verify curveName pubKey pubCommit challenge r = verifyPubKey && verifyPubCommit
   where
-    verifyPubKey = isPointValid Curve.secp256k1 (ECDSA.public_q pubKey)
-        && not (isPointAtInfinity $ pointMul Curve.secp256k1 Curve.h (ECDSA.public_q pubKey))
-    t = pointAddTwoMuls Curve.secp256k1 r Curve.g challenge (ECDSA.public_q pubKey)
+    verifyPubKey = ECC.isPointValid curve (ECDSA.public_q pubKey)
+        && not (ECC.isPointAtInfinity $ ECC.pointMul curve h (ECDSA.public_q pubKey))
+    t = ECC.pointAddTwoMuls curve r g challenge (ECDSA.public_q pubKey)
     verifyPubCommit = pubCommit == t
+    curve = Curve.curve curveName
+    g = Curve.g curveName
+    h = Curve.h curveName
 
 -- | Generate random commitment value
 -- The prover keeps the random value generated safe
 -- while sharing the point in the curve obtained by multiplying G * [k]
-generateCommitment :: MonadRandom m => m (PublicCommitment, PrivateCommitment)
-generateCommitment = do
-  k <- generateBetween 0 (Curve.n-1)
-  let k' = pointBaseMul Curve.secp256k1 k
+generateCommitment
+  :: (MonadRandom m, Curve.Curve c)
+  => c
+  -> m (PublicCommitment, PrivateCommitment)
+generateCommitment curveName = do
+  k <- generateBetween 0 (Curve.n curveName - 1)
+  let k' = ECC.pointBaseMul (Curve.curve curveName) k
   pure (k', k)

--- a/test/GroupLaws.hs
+++ b/test/GroupLaws.hs
@@ -1,4 +1,4 @@
-module TestCommon
+module GroupLaws
   ( commutes
   , associates
   , isIdentity

--- a/test/GroupProperties.hs
+++ b/test/GroupProperties.hs
@@ -1,0 +1,41 @@
+module TestCommon
+  ( commutes
+  , associates
+  , isIdentity
+  , isInverse
+  ) where
+
+import Protolude
+
+commutes
+  :: Eq a
+  => (a -> a -> a)
+  -> a -> a -> Bool
+commutes op x y
+  = (x `op` y) == (y `op` x)
+
+associates
+  :: Eq a
+  => (a -> a -> a)
+  -> a -> a -> a -> Bool
+associates op x y z
+  = (x `op` (y `op` z)) == ((x `op` y) `op` z)
+
+isIdentity
+  :: Eq a
+  => (a -> a -> a)
+  -> a
+  -> a
+  -> Bool
+isIdentity op e x
+  = (x `op` e == x) && (e `op` x == x)
+
+isInverse
+  :: Eq a
+  => (a -> a -> a)
+  -> (a -> a)
+  -> a
+  -> a
+  -> Bool
+isInverse op inv e x
+  = (x `op` inv x == e) && (inv x `op` x == e)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -8,136 +8,26 @@ import           Test.Tasty
 import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck
 import           Crypto.Number.Generate     (generateBetween)
-import qualified Crypto.PubKey.ECC.Generate as ECC
 import qualified Crypto.PubKey.ECC.Prim as ECC
 import qualified Crypto.PubKey.ECC.Types as ECC
+import qualified Crypto.PubKey.ECC.Generate as ECC
+import qualified Crypto.PubKey.ECC.ECDSA    as ECDSA
 
 import           NonInteractive
 import           Interactive
 import           Schnorr
 import qualified Curve
-import GroupProperties
+
+import TestSchnorr
+import TestGroupLaws
+import TestCurveOps
 
 main :: IO ()
 main = defaultMain tests
 
 tests :: TestTree
-tests = testGroup "Tests" [
-  schnorrTests,
-  test_groupLaws_SEC_p256k1,
-  test_groupLaws_Curve25519
+tests = testGroup "Tests"
+  [ testGroupLaws
+  , testCurveOps
+  , testSchnorr
   ]
-
-genPoint :: ECC.Curve -> Gen ECC.Point
-genPoint curve = ECC.generateQ curve <$> arbitrary
-
-testAbelianGroupLaws
-  :: (ECC.Curve -> ECC.Point -> ECC.Point -> ECC.Point)
-  -> (ECC.Curve -> ECC.Point -> ECC.Point)
-  -> ECC.Point
-  -> ECC.Curve
-  -> TestName
-  -> TestTree
-testAbelianGroupLaws binOp neg identity curve descr
-  = testGroup ("Test Abelian group laws of " <> descr)
-    [ testProperty "commutativity of addition"
-      $ forAll (genPoint curve) $ \p1
-      -> forAll (genPoint curve) $ \p2
-      -> commutes (binOp curve) p1 p2
-
-    , testProperty "commutativity of addition"
-        $ forAll (genPoint curve) $ \p1
-        -> forAll (genPoint curve) $ \p2
-        -> forAll (genPoint curve) $ \p3
-        -> associates (binOp curve) p1 p2 p3
-
-    , testProperty "additive identity"
-      $ forAll (genPoint curve) $ isIdentity (binOp curve) identity
-
-    , testProperty "additive inverse"
-      $ forAll (genPoint curve) $ isInverse (binOp curve) (neg curve) identity
-    ]
-
-test_groupLaws_SEC_p256k1 :: TestTree
-test_groupLaws_SEC_p256k1
-  = testAbelianGroupLaws
-      ECC.pointAdd
-      ECC.pointNegate
-      ECC.PointO
-      (ECC.getCurveByName ECC.SEC_p256k1)
-      "SEC_p256k1"
-
-test_groupLaws_Curve25519 :: TestTree
-test_groupLaws_Curve25519
-  = testAbelianGroupLaws
-      ECC.pointAdd
-      ECC.pointNegate
-      ECC.PointO
-      Curve.curve25519
-      "Curve25519"
-
-completenessNonInt :: Curve.Curve c => c -> ([Char] -> IO ()) -> IO ()
-completenessNonInt curveName step = do
-    step "Alice generates private and public keys..."
-    (pubKey, privKey) <- generateKeys curveName
-
-    step "Alice also generates private and public commitment values..."
-    (pubCommit, privCommit) <- generateCommitment curveName
-
-    step "Using a secure cryptographic hash function to issue the challenge instead..."
-    let challenge = mkChallenge curveName pubKey pubCommit
-
-    step "Alice computes the response..."
-    let resp = computeResponse curveName privCommit privKey challenge
-
-    step "Bob only verifies that Alice knows the value of the private key..."
-    assertBool "Non-Interactive Schnorr doesn't work" $
-      verify curveName pubKey pubCommit challenge resp
-
-soundnessNonInt :: Curve.Curve c => c -> ([Char] -> IO ()) -> IO ()
-soundnessNonInt curveName step = do
-    step "Alice generates private and public keys..."
-    (pubKey, privKey) <- generateKeys curveName
-
-    step "Alice also generates private and public commitment values..."
-    (pubCommit, privCommit) <- generateCommitment curveName
-
-    step "Using a secure cryptographic hash function to issue the challenge instead..."
-    let challenge = mkChallenge curveName pubKey pubCommit
-
-    step "Alice computes the response but doesn't know the random commitment private value..."
-    randomPrivCommit <- generateBetween 1 (Curve.n curveName - 1)
-    let resp = computeResponse curveName randomPrivCommit privKey challenge
-
-    step "Bob only verifies that Alice knows the value of the private key..."
-    assertBool "Non-Interactive Schnorr doesn't work" $
-      not $ verify curveName pubKey pubCommit challenge resp
-
-schnorrTests = testGroup "Schnorr Indentification Schemes"
-  [ testCaseSteps
-      "Non-interactive. Completeness property. Secp256k1 Curve"
-      (completenessNonInt ECC.SEC_p256k1)
-
-  , testCaseSteps
-      "Non-interactive. Soundness property. Secp256k1 Curve"
-      (soundnessNonInt ECC.SEC_p256k1)
-
-  , testCaseSteps
-      "Non-interactive. Completeness property. Curve25519 Curve"
-      (completenessNonInt Curve.Curve25519)
-
-  , testCaseSteps
-      "Non-interactive. Soundness property. Curve25519 Curve"
-      (soundnessNonInt Curve.Curve25519)
-
-  , testProperty "Interactive. Secp256k1 Curve" (interactiveTest ECC.SEC_p256k1)
-  ]
-
-
-interactiveTest :: Curve.Curve c => c -> [Char] -> Property
-interactiveTest curveName msg = monadicIO $ do
-  (pubKey, privKey) <- liftIO $ generateKeys curveName
-  (pubCommit, privCommit) <- liftIO $ generateCommitment curveName
-  challenge <- liftIO $ generateChallenge (show msg)
-  let r = computeResponse curveName privCommit privKey challenge
-  pure $ verify curveName pubKey pubCommit challenge r

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -9,6 +9,7 @@ import           Test.Tasty
 import           Test.Tasty.HUnit
 import           Test.Tasty.QuickCheck
 import           Crypto.Number.Generate     (generateBetween)
+import qualified Crypto.PubKey.ECC.Types as ECC
 
 import           NonInteractive
 import           Interactive
@@ -21,49 +22,68 @@ main = defaultMain tests
 tests :: TestTree
 tests = testGroup "Tests" [schnorrTests]
 
+completenessNonInt :: Curve.Curve c => c -> ([Char] -> IO ()) -> IO ()
+completenessNonInt curveName step = do
+    step "Alice generates private and public keys..."
+    (pubKey, privKey) <- generateKeys curveName
+
+    step "Alice also generates private and public commitment values..."
+    (pubCommit, privCommit) <- generateCommitment curveName
+
+    step "Using a secure cryptographic hash function to issue the challenge instead..."
+    let challenge = mkChallenge curveName pubKey pubCommit
+
+    step "Alice computes the response..."
+    let resp = computeResponse curveName privCommit privKey challenge
+
+    step "Bob only verifies that Alice knows the value of the private key..."
+    assertBool "Non-Interactive Schnorr doesn't work" $
+      verify curveName pubKey pubCommit challenge resp
+
+soundnessNonInt :: Curve.Curve c => c -> ([Char] -> IO ()) -> IO ()
+soundnessNonInt curveName step = do
+    step "Alice generates private and public keys..."
+    (pubKey, privKey) <- generateKeys curveName
+
+    step "Alice also generates private and public commitment values..."
+    (pubCommit, privCommit) <- generateCommitment curveName
+
+    step "Using a secure cryptographic hash function to issue the challenge instead..."
+    let challenge = mkChallenge curveName pubKey pubCommit
+
+    step "Alice computes the response but doesn't know the random commitment private value..."
+    randomPrivCommit <- generateBetween 1 (Curve.n curveName - 1)
+    let resp = computeResponse curveName randomPrivCommit privKey challenge
+
+    step "Bob only verifies that Alice knows the value of the private key..."
+    assertBool "Non-Interactive Schnorr doesn't work" $
+      not $ verify curveName pubKey pubCommit challenge resp
+
 schnorrTests = testGroup "Schnorr Indentification Schemes"
-  [ testCaseSteps "Non-interactive. Completeness property" $ \step -> do
-      step "Alice generates private and public keys..."
-      (pubKey, privKey) <- generateKeys
+  [ testCaseSteps
+      "Non-interactive. Completeness property. Secp256k1 Curve"
+      (completenessNonInt ECC.SEC_p256k1)
 
-      step "Alice also generates private and public commitment values..."
-      (pubCommit, privCommit) <- generateCommitment
+  , testCaseSteps
+      "Non-interactive. Soundness property. Secp256k1 Curve"
+      (soundnessNonInt ECC.SEC_p256k1)
 
-      step "Using a secure cryptographic hash function to issue the challenge instead..."
-      let challenge = mkChallenge pubKey pubCommit
+  -- , testCaseSteps
+  --     "Non-interactive. Completeness property. Curve25519 Curve"
+  --     (completenessNonInt ECC.Curve25519)
+  --
+  -- , testCaseSteps
+  --     "Non-interactive. Soundness property. Curve25519 Curve"
+  --     (soundnessNonInt ECC.Curve25519)
 
-      step "Alice computes the response..."
-      let resp = computeResponse privCommit privKey challenge
-
-      step "Bob only verifies that Alice knows the value of the private key..."
-      assertBool "Non-Interactive Schnorr doesn't work" $ verify pubKey pubCommit challenge resp
-
-  , testCaseSteps "Non-interactive. Soundness property" $ \step -> do
-      step "Alice generates private and public keys..."
-      (pubKey, privKey) <- generateKeys
-
-      step "Alice also generates private and public commitment values..."
-      (pubCommit, privCommit) <- generateCommitment
-
-      step "Using a secure cryptographic hash function to issue the challenge instead..."
-      let challenge = mkChallenge pubKey pubCommit
-
-      step "Alice computes the response but doesn't know the random commitment private value..."
-      randomPrivCommit <- generateBetween 1 (Curve.n - 1)
-      let resp = computeResponse randomPrivCommit privKey challenge
-
-      step "Bob only verifies that Alice knows the value of the private key..."
-      assertBool "Non-Interactive Schnorr doesn't work" $ not $ verify pubKey pubCommit challenge resp
-
-
-  , testProperty "Interactive" interactiveTest
+  , testProperty "Interactive. Secp256k1 Curve" (interactiveTest ECC.SEC_p256k1)
   ]
 
 
-interactiveTest :: [Char] -> Property
-interactiveTest msg = monadicIO $ do
-    (pubKey, privKey) <- liftIO generateKeys
-    (pubCommit, privCommit) <- liftIO generateCommitment
-    challenge <- liftIO $ generateChallenge (show msg)
-    let r = computeResponse privCommit privKey challenge
-    pure $ verify pubKey pubCommit challenge r
+interactiveTest :: Curve.Curve c => c -> [Char] -> Property
+interactiveTest curveName msg = monadicIO $ do
+  (pubKey, privKey) <- liftIO $ generateKeys curveName
+  (pubCommit, privCommit) <- liftIO $ generateCommitment curveName
+  challenge <- liftIO $ generateChallenge (show msg)
+  let r = computeResponse curveName privCommit privKey challenge
+  pure $ verify curveName pubKey pubCommit challenge r

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -2,7 +2,6 @@
 
 module Main where
 
-import           Data.ByteString
 import           Protolude
 import           Test.QuickCheck.Monadic
 import           Test.Tasty
@@ -68,13 +67,13 @@ schnorrTests = testGroup "Schnorr Indentification Schemes"
       "Non-interactive. Soundness property. Secp256k1 Curve"
       (soundnessNonInt ECC.SEC_p256k1)
 
-  -- , testCaseSteps
-  --     "Non-interactive. Completeness property. Curve25519 Curve"
-  --     (completenessNonInt ECC.Curve25519)
-  --
-  -- , testCaseSteps
-  --     "Non-interactive. Soundness property. Curve25519 Curve"
-  --     (soundnessNonInt ECC.Curve25519)
+  , testCaseSteps
+      "Non-interactive. Completeness property. Curve25519 Curve"
+      (completenessNonInt Curve.Curve25519)
+
+  , testCaseSteps
+      "Non-interactive. Soundness property. Curve25519 Curve"
+      (soundnessNonInt Curve.Curve25519)
 
   , testProperty "Interactive. Secp256k1 Curve" (interactiveTest ECC.SEC_p256k1)
   ]

--- a/test/TestCurveOps.hs
+++ b/test/TestCurveOps.hs
@@ -1,0 +1,102 @@
+module TestCurveOps (testCurveOps) where
+
+-- pointNegate
+-- ( scalarGenerate
+-- , pointAdd
+-- , pointNegate
+-- , pointDouble
+-- , pointBaseMul
+-- , pointMul
+-- , pointAddTwoMuls
+-- , isPointAtInfinity
+-- , isPointValid
+
+import Protolude
+
+import           Test.QuickCheck.Monadic
+import           Test.Tasty
+import           Test.Tasty.HUnit
+import           Test.Tasty.QuickCheck
+
+import           Crypto.Number.Generate     (generateBetween)
+import qualified Crypto.PubKey.ECC.Prim as ECC
+import qualified Crypto.PubKey.ECC.Types as ECC
+import qualified Crypto.PubKey.ECC.Generate as ECC
+import qualified Crypto.PubKey.ECC.ECDSA    as ECDSA
+
+import qualified Curve
+import qualified Curve25519
+
+testCurveOps :: TestTree
+testCurveOps = testGroup "Curve operations"
+  [ testCase
+      "Curve generator g is valid point. Curve25519"
+      (gIsPointValid Curve.Curve25519)
+
+  , testProperty
+      "A randomly generated point is valid point. Curve25519"
+      (rndIsPointValid Curve.Curve25519)
+
+  , testProperty
+      "A generated public key is valid point. Curve25519"
+      (publicKeyIsPointValid Curve.Curve25519)
+
+  , testProperty
+      "The result of adding two points is valid point. Curve25519"
+      (pointAddIsPointValid Curve.Curve25519)
+
+  , testProperty
+      "The result of doubling a point is valid point. Curve25519"
+      (pointDoubleIsPointValid Curve.Curve25519)
+
+  , testProperty
+      "The result of multiplying a point by a scalar is valid point. Curve25519"
+      (pointMulIsPointValid Curve.Curve25519)
+  ]
+
+rndIsPointValid :: Curve.Curve c => c -> Property
+rndIsPointValid curveName = monadicIO $ do
+  d <- liftIO $ generateBetween 1 (Curve.n curveName - 1)
+  let point = Curve.generateQ curveName d
+  pure $ Curve.isPointValid curveName point
+
+publicKeyIsPointValid :: Curve.Curve c => c -> Property
+publicKeyIsPointValid curveName = monadicIO $ do
+  (pubKey, privKey) <- liftIO $ Curve.generateKeys curveName
+  pure $ Curve.isPointValid curveName (ECDSA.public_q pubKey)
+
+gIsPointValid :: Curve.Curve c => c -> Assertion
+gIsPointValid curveName = assertBool "generator g is not a valid point" $
+  Curve.isPointValid curveName (Curve.g curveName)
+
+pointAddIsPointValid :: Curve.Curve c => c -> Property
+pointAddIsPointValid curveName = monadicIO $ do
+  -- Generate point 1
+  d1 <- liftIO $ generateBetween 1 (Curve.n curveName - 1)
+  let p1 = Curve.generateQ curveName d1
+  -- Generate point 2
+  d2 <- liftIO $  generateBetween 1 (Curve.n curveName - 1)
+  let p2 = Curve.generateQ curveName d2
+
+  let result = Curve.pointAdd curveName p1 p2
+  pure $ Curve.isPointValid curveName result
+
+pointDoubleIsPointValid :: Curve.Curve c => c -> Property
+pointDoubleIsPointValid curveName = monadicIO $ do
+  -- Generate point
+  d <- liftIO $ generateBetween 1 (Curve.n curveName - 1)
+  let p = Curve.generateQ curveName d
+  let result = Curve.pointAdd curveName p p
+  pure $ Curve.isPointValid curveName result
+
+pointMulIsPointValid :: Curve.Curve c => c -> Property
+pointMulIsPointValid curveName = monadicIO $ do
+  -- Generate scalar
+  m <- liftIO $ generateBetween 1 (Curve.n curveName - 1)
+
+  -- Generate point
+  d <- liftIO $  generateBetween 1 (Curve.n curveName - 1)
+  let p = Curve.generateQ curveName d
+
+  let result = Curve.pointMul curveName m p
+  pure $ Curve.isPointValid curveName result

--- a/test/TestCurveOps.hs
+++ b/test/TestCurveOps.hs
@@ -1,16 +1,5 @@
 module TestCurveOps (testCurveOps) where
 
--- pointNegate
--- ( scalarGenerate
--- , pointAdd
--- , pointNegate
--- , pointDouble
--- , pointBaseMul
--- , pointMul
--- , pointAddTwoMuls
--- , isPointAtInfinity
--- , isPointValid
-
 import Protolude
 
 import           Test.QuickCheck.Monadic
@@ -29,29 +18,35 @@ import qualified Curve25519
 
 testCurveOps :: TestTree
 testCurveOps = testGroup "Curve operations"
+  [ testCurveOps' Curve.Curve25519
+  , testCurveOps' $ Curve.SECCurve ECC.SEC_p256k1
+  ]
+
+testCurveOps' :: Curve.Curve c => c -> TestTree
+testCurveOps' curveName = testGroup ("Curve: " <> show curveName)
   [ testCase
-      "Curve generator g is valid point. Curve25519"
-      (gIsPointValid Curve.Curve25519)
+      "Curve generator g is valid point."
+      (gIsPointValid curveName)
 
   , testProperty
-      "A randomly generated point is valid point. Curve25519"
-      (rndIsPointValid Curve.Curve25519)
+      "A randomly generated point is valid point."
+      (rndIsPointValid curveName)
 
   , testProperty
-      "A generated public key is valid point. Curve25519"
-      (publicKeyIsPointValid Curve.Curve25519)
+      "A generated public key is valid point."
+      (publicKeyIsPointValid curveName)
 
   , testProperty
-      "The result of adding two points is valid point. Curve25519"
-      (pointAddIsPointValid Curve.Curve25519)
+      "The result of adding two points is valid point."
+      (pointAddIsPointValid curveName)
 
   , testProperty
-      "The result of doubling a point is valid point. Curve25519"
-      (pointDoubleIsPointValid Curve.Curve25519)
+      "The result of doubling a point is valid point."
+      (pointDoubleIsPointValid curveName)
 
   , testProperty
-      "The result of multiplying a point by a scalar is valid point. Curve25519"
-      (pointMulIsPointValid Curve.Curve25519)
+      "The result of multiplying a point by a scalar is valid point."
+      (pointMulIsPointValid curveName)
   ]
 
 rndIsPointValid :: Curve.Curve c => c -> Property

--- a/test/TestGroupLaws.hs
+++ b/test/TestGroupLaws.hs
@@ -1,0 +1,60 @@
+module TestGroupLaws
+  ( testGroupLaws
+  ) where
+
+import           Protolude
+import           Test.QuickCheck.Monadic
+import           Test.Tasty
+import           Test.Tasty.HUnit
+import           Test.Tasty.QuickCheck
+import qualified Crypto.PubKey.ECC.Generate as ECC
+import qualified Crypto.PubKey.ECC.Prim as ECC
+import qualified Crypto.PubKey.ECC.Types as ECC
+
+import Curve
+import GroupLaws
+
+genPoint :: ECC.Curve -> Gen ECC.Point
+genPoint curve = ECC.generateQ curve <$> arbitrary
+
+testAbelianGroupLaws
+  :: (ECC.Curve -> ECC.Point -> ECC.Point -> ECC.Point)
+  -> (ECC.Curve -> ECC.Point -> ECC.Point)
+  -> ECC.Point
+  -> ECC.Curve
+  -> TestName
+  -> TestTree
+testAbelianGroupLaws binOp neg identity curve descr
+  = testGroup ("Test Abelian group laws of " <> descr)
+    [ testProperty "commutativity of addition"
+      $ forAll (genPoint curve) $ \p1
+      -> forAll (genPoint curve) $ \p2
+      -> commutes (binOp curve) p1 p2
+
+    , testProperty "commutativity of addition"
+        $ forAll (genPoint curve) $ \p1
+        -> forAll (genPoint curve) $ \p2
+        -> forAll (genPoint curve) $ \p3
+        -> associates (binOp curve) p1 p2 p3
+
+    , testProperty "additive identity"
+      $ forAll (genPoint curve) $ isIdentity (binOp curve) identity
+
+    , testProperty "additive inverse"
+      $ forAll (genPoint curve) $ isInverse (binOp curve) (neg curve) identity
+    ]
+
+testCurveGroupLaws :: Curve c => c -> TestTree
+testCurveGroupLaws curveName =
+  testAbelianGroupLaws
+      ECC.pointAdd
+      ECC.pointNegate
+      ECC.PointO
+      (curve curveName)
+      (show curveName)
+
+testGroupLaws :: TestTree
+testGroupLaws = testGroup "Tests Group Laws" [
+  testCurveGroupLaws Curve25519,
+  testCurveGroupLaws (SECCurve ECC.SEC_p256k1)
+  ]

--- a/test/TestSchnorr.hs
+++ b/test/TestSchnorr.hs
@@ -18,24 +18,21 @@ import           Curve
 
 testSchnorr :: TestTree
 testSchnorr = testGroup "Schnorr Indentification Schemes"
+  [ testSchnorr' $ SECCurve ECC.SEC_p256k1
+  , testSchnorr' Curve25519
+  ]
+
+testSchnorr' :: Curve c => c -> TestTree
+testSchnorr' curveName = testGroup ("Curve: " <> show curveName)
   [ testCaseSteps
-      "Non-interactive. Completeness property. Secp256k1 Curve"
-      (completenessNonInt $ SECCurve ECC.SEC_p256k1)
+      "Non-interactive variant. Completeness property."
+      (completenessNonInt curveName)
 
   , testCaseSteps
-      "Non-interactive. Soundness property. Secp256k1 Curve"
-      (soundnessNonInt $ SECCurve ECC.SEC_p256k1)
+      "Non-interactive variant. Soundness property."
+      (soundnessNonInt curveName)
 
-  , testCaseSteps
-      "Non-interactive. Completeness property. Curve25519 Curve"
-      (completenessNonInt Curve25519)
-
-  , testCaseSteps
-      "Non-interactive. Soundness property. Curve25519 Curve"
-      (soundnessNonInt Curve25519)
-
-  , testProperty "Interactive. Secp256k1 Curve" (interactiveTest $ SECCurve ECC.SEC_p256k1)
-  , testProperty "Interactive. Curve25519 Curve" (interactiveTest Curve25519)
+  , testProperty "Interactive variant." (interactiveTest curveName)
   ]
 
 completenessNonInt :: Curve c => c -> ([Char] -> IO ()) -> IO ()

--- a/test/TestSchnorr.hs
+++ b/test/TestSchnorr.hs
@@ -1,0 +1,86 @@
+module TestSchnorr where
+
+import           Protolude
+import           Test.QuickCheck.Monadic
+import           Test.Tasty
+import           Test.Tasty.HUnit
+import           Test.Tasty.QuickCheck
+import           Crypto.Number.Generate     (generateBetween)
+import qualified Crypto.PubKey.ECC.Prim as ECC
+import qualified Crypto.PubKey.ECC.Types as ECC
+import qualified Crypto.PubKey.ECC.Generate as ECC
+import qualified Crypto.PubKey.ECC.ECDSA    as ECDSA
+
+import           NonInteractive
+import           Interactive
+import           Schnorr
+import           Curve
+
+testSchnorr :: TestTree
+testSchnorr = testGroup "Schnorr Indentification Schemes"
+  [ testCaseSteps
+      "Non-interactive. Completeness property. Secp256k1 Curve"
+      (completenessNonInt $ SECCurve ECC.SEC_p256k1)
+
+  , testCaseSteps
+      "Non-interactive. Soundness property. Secp256k1 Curve"
+      (soundnessNonInt $ SECCurve ECC.SEC_p256k1)
+
+  , testCaseSteps
+      "Non-interactive. Completeness property. Curve25519 Curve"
+      (completenessNonInt Curve25519)
+
+  , testCaseSteps
+      "Non-interactive. Soundness property. Curve25519 Curve"
+      (soundnessNonInt Curve25519)
+
+  , testProperty "Interactive. Secp256k1 Curve" (interactiveTest $ SECCurve ECC.SEC_p256k1)
+  , testProperty "Interactive. Curve25519 Curve" (interactiveTest Curve25519)
+  ]
+
+completenessNonInt :: Curve c => c -> ([Char] -> IO ()) -> IO ()
+completenessNonInt curveName step = do
+    step "Alice generates private and public keys..."
+    (pubKey, privKey) <- generateKeys curveName
+
+    step "Alice also generates private and public commitment values..."
+    (pubCommit, privCommit) <- generateCommitment curveName
+
+    step "Using a secure cryptographic hash function to issue the challenge instead..."
+    let challenge = mkChallenge curveName pubKey pubCommit
+
+    step "Alice computes the response..."
+    let resp = computeResponse curveName privCommit privKey challenge
+
+    step "Bob only verifies that Alice knows the value of the private key..."
+
+    let verified = verify curveName pubKey pubCommit challenge resp
+    assertBool "Non-Interactive Schnorr doesn't work" verified
+
+
+soundnessNonInt :: Curve c => c -> ([Char] -> IO ()) -> IO ()
+soundnessNonInt curveName step = do
+    step "Alice generates private and public keys..."
+    (pubKey, privKey) <- generateKeys curveName
+
+    step "Alice also generates private and public commitment values..."
+    (pubCommit, privCommit) <- generateCommitment curveName
+
+    step "Using a secure cryptographic hash function to issue the challenge instead..."
+    let challenge = mkChallenge curveName pubKey pubCommit
+
+    step "Alice computes the response but doesn't know the random commitment private value..."
+    randomPrivCommit <- generateBetween 1 (n curveName - 1)
+    let resp = computeResponse curveName randomPrivCommit privKey challenge
+
+    step "Bob only verifies that Alice knows the value of the private key..."
+    assertBool "Non-Interactive Schnorr doesn't work" $
+      not $ verify curveName pubKey pubCommit challenge resp
+
+interactiveTest :: Curve c => c -> [Char] -> Property
+interactiveTest curveName msg = monadicIO $ do
+  (pubKey, privKey) <- liftIO $ generateKeys curveName
+  (pubCommit, privCommit) <- liftIO $ generateCommitment curveName
+  challenge <- liftIO $ generateChallenge (show msg)
+  let r = computeResponse curveName privCommit privKey challenge
+  pure $ verify curveName pubKey pubCommit challenge r


### PR DESCRIPTION
It abstracts the implementation to allow the protocol use different curves. Specifically, we want to make it work with Secp256k1 and Curve25519 